### PR TITLE
Fixed for BrainTree connector automation

### DIFF
--- a/braintree/braintree-connector/braintree-connector-1.0.0/org.wso2.carbon.connector/src/test/java/org/wso2/carbon/connector/integration/test/braintree/BraintreeConnectorIntegrationTest.java
+++ b/braintree/braintree-connector/braintree-connector-1.0.0/org.wso2.carbon.connector/src/test/java/org/wso2/carbon/connector/integration/test/braintree/BraintreeConnectorIntegrationTest.java
@@ -889,7 +889,7 @@ public class BraintreeConnectorIntegrationTest extends ConnectorIntegrationTestB
      * @throws JSONException
      * @throws IOException
      */
-    @Test(dependsOnMethods = { "testVoidTransactionWithMandatoryParameters" }, description = "Braintree {refundTransaction} integration test with Mandatory parameters.")
+    @Test(dependsOnMethods = { "testVoidTransactionWithMandatoryParameters" }, enabled=false, description = "Braintree {refundTransaction} integration test with Mandatory parameters.")
     public void testRefundTransactionWithMandatoryParameters() throws IOException, JSONException {
 
         esbRequestHeadersMap.put("Action", "urn:refundTransaction");
@@ -926,7 +926,7 @@ public class BraintreeConnectorIntegrationTest extends ConnectorIntegrationTestB
      * @throws JSONException
      * @throws IOException
      */
-    @Test(dependsOnMethods = { "testVoidTransactionWithMandatoryParameters" }, description = "Braintree {refundTransaction} integration test with Optional parameters.")
+    @Test(dependsOnMethods = { "testVoidTransactionWithMandatoryParameters" }, enabled=false, description = "Braintree {refundTransaction} integration test with Optional parameters.")
     public void testRefundTransactionWithOptionalParameters() throws IOException, JSONException {
 
         esbRequestHeadersMap.put("Action", "urn:refundTransaction");


### PR DESCRIPTION
The following comments is mentioned in the README File.

"Settlement of transaction is a scheduled backend process which takes around a day to be processed.
The 'testRefundTransactionWithMandatoryParameters' and 'testRefundTransactionWithOptionalParameters' are made to fail."

So For the automation we will disable the two test cases.
